### PR TITLE
fix: use official Redis Docker image instead of daocloud.io

### DIFF
--- a/test/test_k3redisutil.py
+++ b/test/test_k3redisutil.py
@@ -16,7 +16,7 @@ import k3utfjson
 
 dd = k3ut.dd
 
-redis_tag = "daocloud.io/redis:3.2.3"
+redis_tag = "redis:7-alpine"
 
 redis_port = 6379
 


### PR DESCRIPTION
## Summary
Fix CI failures by switching from `daocloud.io/redis:3.2.3` to the official `redis:7-alpine` Docker image.

## Problem
The `daocloud.io` registry is blocked/inaccessible from GitHub Actions, causing all Docker-dependent tests to fail with HTTP 500 errors when trying to pull the image.

## Solution
Update `redis_tag` in `test/test_k3redisutil.py` to use the official Redis image:
- From: `daocloud.io/redis:3.2.3`
- To: `redis:7-alpine`

## Test plan
- [ ] CI tests pass (TestRedis.test_set_get, TestRedisRecreate.test_recreate_client)